### PR TITLE
Fix introductory README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # saychord-demo
-"SayChord est une application web de dictée vocale d'accords musicaux. Elle permet aux musiciens de dicter des accords, de les entendre joués avec un son de piano électrique FM, de créer des séquences et des boucles, et d'exporter leurs créations. Ce dépôt contient le code source de la version démo de l'application."
+"SayChord est une application web de dictée vocale d'accords musicaux.
+Elle permet aux musiciens de dicter des accords, de les entendre joués avec un son de piano électrique FM, de créer des séquences et des boucles, et d'exporter leurs créations. Ce dépôt contient le code source de la version démo de l'application."


### PR DESCRIPTION
## Summary
- fix the broken word by making "Elle permet" a single line

## Testing
- `nl -ba README.md`

------
https://chatgpt.com/codex/tasks/task_e_688369f66ae88322b9b11e18f541bca9