### PR TITLE
Add Python backend for chord mapping and exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/saychord/__init__.py
+++ b/saychord/__init__.py
@@ -1,0 +1,21 @@
+from .models import (
+    ChordSymbol,
+    Block,
+    Section,
+    Progression,
+    Style,
+)
+from .processing import (
+    normalize_chord_symbol,
+    map_chord_to_style,
+    assign_atr,
+    suggest_drum_tags,
+    generate_automation,
+    validate_style,
+)
+from .export import (
+    export_csv_plan,
+    export_musicxml,
+    export_midi,
+)
+

--- a/saychord/export.py
+++ b/saychord/export.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import List
+from music21 import stream, harmony, meter, tempo, midi
+
+from .models import Progression
+
+
+def _progression_to_stream(prog: Progression) -> stream.Stream:
+    s = stream.Stream()
+    s.append(meter.TimeSignature(prog.time_signature))
+    s.append(tempo.MetronomeMark(number=prog.bpm))
+    for section in prog.sections:
+        for block in section.blocks:
+            cs = harmony.ChordSymbol(block.chord.to_string())
+            cs.quarterLength = block.beats
+            s.append(cs)
+    return s
+
+
+def export_csv_plan(prog: Progression) -> str:
+    lines: List[str] = ["section,bar,startBeat,beats,chord,drumTag,notes"]
+    for section in prog.sections:
+        for block in section.blocks:
+            chord_str = block.chord.to_string()
+            role = block.chord.role or ""
+            drum_tag = block.drum_tag or ""
+            lines.append(
+                f"{section.name},{block.bar},{block.start_beat},{block.beats},\"{chord_str}\",{drum_tag},\"{role}\""
+            )
+    return "\n".join(lines)
+
+
+def export_musicxml(prog: Progression) -> bytes:
+    s = _progression_to_stream(prog)
+    bio = BytesIO()
+    s.write("musicxml", fp=bio)
+    return bio.getvalue()
+
+
+def export_midi(prog: Progression) -> bytes:
+    s = _progression_to_stream(prog)
+    mf = midi.translate.streamToMidiFile(s)
+    bio = BytesIO()
+    mf.open(bio, "wb")
+    mf.write()
+    mf.close()
+    return bio.getvalue()

--- a/saychord/models.py
+++ b/saychord/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Any
+import json
+
+
+@dataclass
+class ChordSymbol:
+    root: str
+    quality: str
+    extensions: List[str] = field(default_factory=list)
+    bass: Optional[str] = None
+    degree: Optional[str] = None
+    role: Optional[str] = None  # A, T, R
+
+    def to_string(self) -> str:
+        ext = ''.join(self.extensions)
+        bass_part = f"/{self.bass}" if self.bass else ""
+        return f"{self.root}{self.quality}{ext}{bass_part}"
+
+
+@dataclass
+class Block:
+    bar: int
+    start_beat: int
+    beats: int
+    chord: ChordSymbol
+    drum_tag: Optional[str] = None
+    comment: Optional[str] = None
+
+
+@dataclass
+class Section:
+    name: str
+    repeat: int
+    blocks: List[Block]
+
+
+@dataclass
+class Progression:
+    title: str
+    style_id: str
+    time_signature: str
+    bpm: int
+    transpose_semitones: int
+    sections: List[Section]
+
+
+@dataclass
+class Style:
+    id: str
+    name: str
+    time_signature: str
+    default_bpm: int
+    available_chords: Dict[str, List[str]]
+    drum_grooves: Dict[str, List[str]]
+    tempo_range: Optional[List[int]] = None
+    app_family: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "Style":
+        return cls(
+            id=data["id"],
+            name=data.get("name", data["id"]),
+            time_signature=data["time_signature"],
+            default_bpm=data.get("default_bpm", 120),
+            available_chords=data.get("available_chords", {}),
+            drum_grooves=data.get("drum_grooves", {}),
+            tempo_range=data.get("tempo_range"),
+            app_family=data.get("app_family"),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "Style":
+        with open(path) as fh:
+            data = json.load(fh)
+        return cls.from_json(data)

--- a/saychord/processing.py
+++ b/saychord/processing.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import re
+from typing import List
+from .models import (
+    ChordSymbol,
+    Block,
+    Section,
+    Progression,
+    Style,
+)
+
+ROOT_RE = re.compile(r"^([A-G](?:b|#)?)")
+SLASH_RE = re.compile(r"/(.*)$")
+EXT_TOKENS = ["#9", "b9", "#11", "b13", "13", "9", "add9"]
+QUALITY_TOKENS = [
+    "maj7#11",
+    "maj7",
+    "maj9",
+    "maj",
+    "m9b5",
+    "m11",
+    "m9",
+    "m7b5",
+    "m7",
+    "m",
+    "13#11",
+    "13",
+    "7#9",
+    "7b9",
+    "7alt",
+    "7",
+    "dim",
+    "sus4",
+    "alt",
+    "add9",
+]
+
+
+def _strip_parentheses(text: str) -> str:
+    return text.replace("(", "").replace(")", "")
+
+
+def normalize_chord_symbol(raw: str) -> ChordSymbol:
+    raw = raw.strip()
+    raw = _strip_parentheses(raw)
+    # parse bass
+    bass = None
+    m = SLASH_RE.search(raw)
+    if m:
+        bass = m.group(1)
+        raw = raw[: m.start()]
+
+    m = ROOT_RE.match(raw)
+    if not m:
+        raise ValueError(f"Invalid chord symbol: {raw}")
+    root = m.group(1)
+    rest = raw[m.end() :]
+
+    quality = None
+    for token in QUALITY_TOKENS:
+        if rest.startswith(token):
+            quality = token
+            rest = rest[len(token) :]
+            break
+    if quality is None:
+        quality = rest or "maj"
+
+    # qualities that embed extensions
+    embedded_exts: List[str] = []
+    if quality in {"7#9", "7b9"}:
+        embedded_exts.append(quality[1:])
+        quality = "7"
+    elif quality == "13#11":
+        embedded_exts.append("#11")
+        quality = "13"
+    elif quality == "maj7#11":
+        embedded_exts.append("#11")
+        quality = "maj7"
+
+    extensions: List[str] = []
+    for token in EXT_TOKENS:
+        if token in rest:
+            extensions.append(token)
+            rest = rest.replace(token, "")
+    extensions = embedded_exts + extensions
+    return ChordSymbol(root=root, quality=quality, extensions=extensions, bass=bass)
+
+
+def map_chord_to_style(ch: ChordSymbol, style: Style) -> ChordSymbol:
+    allowed = style.available_chords.get(ch.root, [])
+    if ch.quality in allowed:
+        # some styles encode add9 as quality
+        if "add9" in ch.extensions and ch.quality != "add9" and ch.quality not in allowed:
+            pass
+        return ch
+
+    # handle reductions
+    if ch.quality in {"alt", "7alt"}:
+        for target in ["7#9", "7b9", "7"]:
+            if target in allowed:
+                return ChordSymbol(root=ch.root, quality=target, bass=ch.bass, role=ch.role)
+    if ch.quality == "maj9":
+        if "maj7" in allowed:
+            exts = [e for e in ch.extensions if e != "9"]
+            if "add9" in allowed:
+                exts.append("add9")
+            return ChordSymbol(root=ch.root, quality="maj7", extensions=exts, bass=ch.bass, role=ch.role)
+        if "maj" in allowed:
+            exts = [e for e in ch.extensions if e != "9"]
+            if "add9" in allowed:
+                exts.append("add9")
+            return ChordSymbol(root=ch.root, quality="maj", extensions=exts, bass=ch.bass, role=ch.role)
+    if ch.quality == "m9b5" and "m7b5" in allowed:
+        return ChordSymbol(root=ch.root, quality="m7b5", bass=ch.bass, role=ch.role)
+    if ch.quality == "13#11":
+        if "13" in allowed:
+            return ChordSymbol(root=ch.root, quality="13", bass=ch.bass, role=ch.role)
+        if "maj7" in allowed:
+            return ChordSymbol(root=ch.root, quality="maj7", extensions=["#11"], bass=ch.bass, role=ch.role)
+    if ch.quality == "maj" and "maj7" in allowed:
+        return ChordSymbol(root=ch.root, quality="maj7", extensions=ch.extensions, bass=ch.bass, role=ch.role)
+    if ch.quality == "add9" and "maj" in allowed:
+        return ChordSymbol(root=ch.root, quality="maj", extensions=["add9"], bass=ch.bass, role=ch.role)
+
+    raise ValueError(f"Chord {ch.to_string()} not available in style {style.id}")
+
+
+def assign_atr(prog: Progression) -> None:
+    for section in prog.sections:
+        for block in section.blocks:
+            q = block.chord.quality
+            if q.startswith("m") and "b5" not in q:
+                role = "A"
+            elif "7" in q or q in {"13", "dim"}:
+                role = "T"
+            elif q.startswith("maj") or q == "maj" or q == "add9":
+                role = "R"
+            else:
+                role = "A"
+            block.chord.role = role
+
+
+def suggest_drum_tags(prog: Progression, style: Style) -> None:
+    fills = style.drum_grooves.get("fills", [])
+    normals = style.drum_grooves.get("normal", [])
+    normal_idx = 0
+    for i, section in enumerate(prog.sections):
+        for block in section.blocks:
+            block.drum_tag = None
+        if normals:
+            for block in section.blocks:
+                block.drum_tag = normals[normal_idx % len(normals)]
+                normal_idx += 1
+        # place fill before chorus/bridge
+        if fills and i + 1 < len(prog.sections):
+            next_name = prog.sections[i + 1].name.lower()
+            if "chorus" in next_name or "bridge" in next_name:
+                last_block = section.blocks[-1]
+                last_block.drum_tag = fills[0]
+
+
+def generate_automation(prog: Progression, style: Style) -> dict:
+    auto = {"automation": [], "cues": []}
+    for i, section in enumerate(prog.sections):
+        first_block = section.blocks[0]
+        if "chorus" in section.name.lower():
+            bar = first_block.bar
+            auto["automation"].append({
+                "track": "piano",
+                "param": "volume",
+                "points": [{"bar": bar, "beat": first_block.start_beat, "value": 0.8}],
+            })
+            auto["automation"].append({
+                "track": "pads",
+                "param": "volume",
+                "points": [{"bar": bar, "beat": first_block.start_beat, "value": 0.7}],
+            })
+            auto["cues"].append({
+                "bar": bar - 1,
+                "beat": section.blocks[-1].beats,
+                "type": "fill",
+                "tag": style.drum_grooves.get("fills", [None])[0],
+            })
+    return auto
+
+
+def validate_style(prog: Progression, style: Style) -> None:
+    if prog.time_signature != style.time_signature:
+        raise ValueError(
+            f"Style {style.id} incompatible with time signature {prog.time_signature}"
+        )
+

--- a/saychord/styles/jazz.vol4.ballad.ecm.4-4.json
+++ b/saychord/styles/jazz.vol4.ballad.ecm.4-4.json
@@ -1,0 +1,17 @@
+{
+  "id": "jazz.vol4.ballad.ecm.4-4",
+  "name": "ECM Ballad",
+  "time_signature": "4/4",
+  "default_bpm": 72,
+  "available_chords": {
+    "C": ["maj","maj7","add9","maj7#11","6/9"],
+    "C#": ["maj","maj7","add9"],
+    "D": ["m7","m9","m11","sus4","add9"],
+    "G": ["7","7#9","7b9","13","13#11","sus4"],
+    "A": ["m7b5","dim","7","7b9"]
+  },
+  "drum_grooves": {
+    "normal": ["DRUM_1","DRUM_2","DRUM_3"],
+    "fills": ["FILL_1","FILL_2","FILL_3","FILL_4"]
+  }
+}

--- a/saychord/styles/popjazz.valse.3-4.json
+++ b/saychord/styles/popjazz.valse.3-4.json
@@ -1,0 +1,18 @@
+{
+  "id": "popjazz.valse.3-4",
+  "name": "Pop-Jazz Waltz",
+  "time_signature": "3/4",
+  "default_bpm": 84,
+  "available_chords": {
+    "D": ["maj","maj7","add9","maj7#11"],
+    "G": ["maj7","maj7#11","sus4"],
+    "A": ["7","7#9","7b9","sus4"],
+    "Bm": ["m7","m9"],
+    "E": ["7","7b9"],
+    "Em": ["m7","m9"]
+  },
+  "drum_grooves": {
+    "normal": ["DRUM_1","DRUM_2"],
+    "fills": ["FILL_1","FILL_2","FILL_3"]
+  }
+}

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,61 @@
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from saychord import (
+    Style,
+    normalize_chord_symbol,
+    map_chord_to_style,
+    validate_style,
+    export_csv_plan,
+    Block,
+    Section,
+    Progression,
+)
+
+
+def load_style(path):
+    return Style.load(path)
+
+
+def test_map_alt_reduction():
+    style = load_style('saychord/styles/jazz.vol4.ballad.ecm.4-4.json')
+    ch = normalize_chord_symbol('A7alt')
+    mapped = map_chord_to_style(ch, style)
+    assert mapped.quality == '7b9'
+
+
+def test_style_signature_lock():
+    style = load_style('saychord/styles/jazz.vol4.ballad.ecm.4-4.json')
+    prog = Progression(
+        title='Waltz',
+        style_id='popjazz.valse.3-4',
+        time_signature='3/4',
+        bpm=84,
+        transpose_semitones=0,
+        sections=[],
+    )
+    try:
+        validate_style(prog, style)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('Expected ValueError on time signature mismatch')
+
+
+def test_export_csv_plan():
+    style = load_style('saychord/styles/jazz.vol4.ballad.ecm.4-4.json')
+    ch = map_chord_to_style(normalize_chord_symbol('Cmaj9'), style)
+    block = Block(bar=1, start_beat=1, beats=4, chord=ch)
+    section = Section(name='Intro', repeat=1, blocks=[block])
+    prog = Progression(
+        title='Test',
+        style_id=style.id,
+        time_signature='4/4',
+        bpm=72,
+        transpose_semitones=0,
+        sections=[section],
+    )
+    csv = export_csv_plan(prog)
+    assert 'Cmaj7add9' in csv


### PR DESCRIPTION
## Summary
- define core data models for chords, blocks, sections and styles
- normalize chord symbols and map them to style vocabularies with signature validation
- add CSV, MusicXML and MIDI export helpers and example style JSONs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2b6b3ce188322b586b7c8079b8c7b