### PR TITLE
feat: integrate chord dictionary into voice recognition

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,6 @@ import VoiceRecognitionManager from './voice-recognition.js';
 import SynthesizerEngine from './synthesizer.js';
 import SequenceManager from './sequence-manager.js';
 import UIController from './ui-controller.js';
-import VoiceRecognitionAdapter from './voice-recognition-adapter.js';
 import AudioEnhancer from './audio-enhancer.js';
 
 // Fonction d'initialisation principale
@@ -36,10 +35,6 @@ async function initApp() {
         const voiceRecognition = new VoiceRecognitionManager(chordDictionary);
         console.log('Gestionnaire de reconnaissance vocale initialisé');
         
-        // Initialiser l'adaptateur de reconnaissance vocale
-        const voiceAdapter = new VoiceRecognitionAdapter(voiceRecognition, chordDictionary);
-        console.log('Adaptateur de reconnaissance vocale initialisé');
-        
         // Initialiser le gestionnaire de séquences
         const sequenceManager = new SequenceManager(synthesizer);
         console.log('Gestionnaire de séquences initialisé');
@@ -60,7 +55,6 @@ async function initApp() {
         window.saychordApp = {
             chordDictionary,
             voiceRecognition,
-            voiceAdapter,
             synthesizer,
             audioEnhancer,
             sequenceManager,

--- a/js/voice-recognition-adapter.js
+++ b/js/voice-recognition-adapter.js
@@ -2,7 +2,7 @@
 // Version pour GitHub Pages
 
 class VoiceRecognitionAdapter {
-    constructor() {
+    constructor(chordDictionary) {
         // Dictionnaire de corrections courantes
         this.corrections = {
             // Corrections françaises
@@ -42,6 +42,11 @@ class VoiceRecognitionAdapter {
             'd minor': 'ré mineur',
             'd major': 'ré majeur'
         };
+
+        // Ajouter dynamiquement les alias depuis le dictionnaire d'accords
+        if (chordDictionary && chordDictionary.isLoaded) {
+            this.addDictionaryCorrections(chordDictionary.dictionary);
+        }
         
         // Expressions régulières pour la détection d'accords
         this.chordRegexPatterns = [
@@ -53,6 +58,28 @@ class VoiceRecognitionAdapter {
             /\b([a-g])(?:(#|b))?\s+(minor|major|min|maj)(?:\s+(\d+))?\b/i,
             /\b([a-g])(?:(#|b))?\s+(m|M)(?:(\d+))?\b/i
         ];
+    }
+
+    addDictionaryCorrections(dictionary) {
+        for (const tonalite of Object.values(dictionary.tonalites)) {
+            for (const accord of tonalite.accords) {
+                const canonical = (accord.nom || '').toLowerCase();
+
+                if (accord.nom_fr) {
+                    this.corrections[accord.nom_fr.toLowerCase()] = canonical;
+                }
+
+                if (accord.nom) {
+                    this.corrections[canonical] = canonical;
+                }
+
+                if (Array.isArray(accord.aliases)) {
+                    accord.aliases.forEach(alias => {
+                        this.corrections[alias.toLowerCase()] = canonical;
+                    });
+                }
+            }
+        }
     }
 
     processText(text) {

--- a/js/voice-recognition.js
+++ b/js/voice-recognition.js
@@ -9,7 +9,7 @@ class VoiceRecognition {
         this.isListening = false;
         this.onResultCallback = null;
         this.onErrorCallback = null;
-        this.adapter = new VoiceRecognitionAdapter(); // Utilise l'adaptateur pour améliorer la reconnaissance
+        this.adapter = new VoiceRecognitionAdapter(chordDictionary); // Utilise l'adaptateur pour améliorer la reconnaissance
         this.setupRecognition();
     }
 


### PR DESCRIPTION
## Summary
- generate corrections from chord dictionary aliases for better vocal matching
- instantiate voice recognition adapter with the loaded chord dictionary
- streamline main app initialization by relying on integrated adapter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b190053c508322a9f995613eb0ccee