### PR TITLE
Add SayChord export formats and GPT builder config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # saychord-demo
 "SayChord est une application web de dictée vocale d'accords musicaux. Elle permet aux musiciens de dicter des accords, de les entendre joués avec un son de piano électrique FM, de créer des séquences et des boucles, et d'exporter leurs créations. Ce dépôt contient le code source de la version démo de l'application."
+
+## Nouveautés
+
+- **Exports enrichis** : l'interface web propose maintenant des boutons pour générer directement des fichiers MIDI, MusicXML et ABC grâce au module `SequenceExporter`. Les fichiers sont créés côté navigateur et téléchargés instantanément.
+- **Intégration GPTs** : le fichier [`gpts-builder-config.json`](./gpts-builder-config.json) peut être importé dans le GPTs builder pour configurer l'assistant AiXelMusicOrchestrator avec les bonnes instructions et les points d'accès de l'application.

--- a/css/styles.css
+++ b/css/styles.css
@@ -71,6 +71,18 @@ a:hover {
     background-color: var(--primary-color);
 }
 
+.export-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 15px;
+}
+
+.export-options .btn {
+    flex: 1 1 180px;
+    text-align: center;
+}
+
 /* Header */
 header {
     background-color: white;

--- a/gpts-builder-config.json
+++ b/gpts-builder-config.json
@@ -1,0 +1,65 @@
+{
+  "name": "AiXelMusicOrchestrator",
+  "description": "Assistant musical pour exploiter SayChord et produire des fichiers MIDI/MusicXML/ABC téléchargeables.",
+  "instructions": "1. Utiliser le dictionnaire d'accords public de SayChord pour expliquer les notes et catégories.\n2. Pour des progressions vocales, diriger l'utilisateur vers https://musical-circular-sel-lava.bolt.host et rappeler que la dictée vocale fonctionne mieux dans Chrome/Edge/Safari.\n3. Pour générer un fichier, calculer la suite d'accords (nom, notes) puis retourner la réponse ET un bloc base64 correspondant à l'un des formats supportés (MIDI, MusicXML, ABC) afin que l'utilisateur puisse le télécharger.\n4. Mentionner que l'application web peut aussi exporter directement via window.saychordApp.sequenceManager.exportToMIDI() etc. lorsque l'utilisateur a déjà la page ouverte.\n5. Toujours préciser le tempo et la signature rythmique utilisés pour les fichiers générés.",
+  "conversation_starters": [
+    "Transforme ces accords dictés en fichiers MIDI, MusicXML et ABC.",
+    "Décris-moi comment fonctionne la dictée d'accords SayChord.",
+    "Crée une progression jazz et donne-moi les liens d'export.",
+    "J'ai besoin d'un guide pour utiliser AiXelMusicOrchestrator."
+  ],
+  "knowledge": [
+    {
+      "title": "Application web SayChord",
+      "url": "https://musical-circular-sel-lava.bolt.host",
+      "notes": "Dictée vocale d'accords avec synthèse FM, gestion de séquences, boucle, tempo et exports WAV/PDF/MIDI/MusicXML/ABC."
+    },
+    {
+      "title": "Dictionnaire d'accords",
+      "url": "https://musical-circular-sel-lava.bolt.host/chord-dictionary.json",
+      "notes": "Structure JSON: tonalites -> accords (nom, nom_fr, notes, aliases, categorie, description)."
+    }
+  ],
+  "web_integration": {
+    "window_object": "saychordApp",
+    "sequence_commands": [
+      "window.saychordApp.sequenceManager.exportToMIDI();",
+      "window.saychordApp.sequenceManager.exportToMusicXML();",
+      "window.saychordApp.sequenceManager.exportToABC();"
+    ],
+    "notes": "Ces fonctions créent et téléchargent automatiquement les fichiers depuis l'interface web."
+  },
+  "actions": [
+    {
+      "name": "fetchChordDictionary",
+      "description": "Récupère toutes les définitions d'accords SayChord pour interpréter les commandes vocales.",
+      "method": "GET",
+      "url": "https://musical-circular-sel-lava.bolt.host/chord-dictionary.json",
+      "response_format": "application/json"
+    },
+    {
+      "name": "getWebApp",
+      "description": "Charge l'application web complète (HTML/CSS/JS) si l'utilisateur souhaite l'intégrer dans un iframe ou un navigateur embarqué.",
+      "method": "GET",
+      "url": "https://musical-circular-sel-lava.bolt.host",
+      "response_format": "text/html"
+    }
+  ],
+  "file_generation": {
+    "midi": {
+      "mime_type": "audio/midi",
+      "extension": ".mid",
+      "instructions": "Encapsuler un fichier MIDI de type 1 avec 480 PPQ. Utiliser la suite d'accords décrite par l'utilisateur en assignant chaque accord à une noire." 
+    },
+    "musicxml": {
+      "mime_type": "application/vnd.recordare.musicxml+xml",
+      "extension": ".musicxml",
+      "instructions": "Créer un document score-partwise v3.1 décrivant les harmonies des accords (balises <harmony>) et une note guide par accord." 
+    },
+    "abc": {
+      "mime_type": "text/vnd.abc",
+      "extension": ".abc",
+      "instructions": "Construire une partition ABC (entête X,T,M,L,Q,K) et placer chaque accord sous forme \"Chord\" z." 
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -130,6 +130,9 @@
                 <div class="export-options">
                     <button id="export-wav" class="btn">Exporter en WAV</button>
                     <button id="export-pdf" class="btn btn-secondary">Exporter en PDF</button>
+                    <button id="export-midi" class="btn btn-secondary">Exporter en MIDI</button>
+                    <button id="export-musicxml" class="btn btn-secondary">Exporter en MusicXML</button>
+                    <button id="export-abc" class="btn btn-secondary">Exporter en ABC</button>
                 </div>
             </div>
         </div>

--- a/js/sequence-exporter.js
+++ b/js/sequence-exporter.js
@@ -1,0 +1,350 @@
+/**
+ * Utilities to transform SayChord sequences into shareable files
+ * Supports MIDI, MusicXML and ABC notations so external tools (including GPTs)
+ * can download clean representations of dictated chords.
+ */
+class SequenceExporter {
+    constructor() {
+        this.noteOffsets = {
+            C: 0,
+            D: 2,
+            E: 4,
+            F: 5,
+            G: 7,
+            A: 9,
+            B: 11
+        };
+    }
+
+    /**
+     * Convert current sequence into a simplified structure.
+     * @param {Array} sequence - raw sequence from SequenceManager
+     * @returns {Array}
+     */
+    sanitizeSequence(sequence) {
+        if (!Array.isArray(sequence)) {
+            return [];
+        }
+
+        return sequence
+            .filter(chord => chord)
+            .map((chord, index) => ({
+                name: chord.nom || chord.name || `Accord ${index + 1}`,
+                notes: Array.isArray(chord.notes) ? chord.notes : [],
+                category: chord.categorie || chord.category || 'majeur'
+            }));
+    }
+
+    /**
+     * Create a downloadable MIDI blob from the chord sequence.
+     * @param {Array} sequence - sanitized sequence
+     * @param {number} tempo - BPM
+     * @returns {Blob}
+     */
+    createMIDI(sequence, tempo = 120) {
+        const PPQ = 480;
+        const sanitizedSequence = this.sanitizeSequence(sequence);
+        if (!sanitizedSequence.length) {
+            throw new Error('Séquence vide');
+        }
+
+        const microsecondsPerQuarter = Math.round(60000000 / Math.max(tempo, 40));
+        const events = [];
+
+        // Tempo meta event
+        events.push(...this.writeVariableLength(0), 0xFF, 0x51, 0x03, ...this.numberToBytes(microsecondsPerQuarter, 3));
+
+        sanitizedSequence.forEach((chord, chordIndex) => {
+            const midiNotes = chord.notes
+                .map(note => this.noteNameToMidi(note))
+                .filter(noteNumber => noteNumber !== null);
+
+            if (!midiNotes.length) {
+                return;
+            }
+
+            // Note on events (play simultaneously)
+            midiNotes.forEach((noteNumber, noteIndex) => {
+                const delta = (chordIndex === 0 && noteIndex === 0) ? 0 : 0;
+                events.push(...this.writeVariableLength(delta), 0x90, noteNumber, 0x60);
+            });
+
+            // Note off events after one quarter note
+            midiNotes.forEach((noteNumber, noteIndex) => {
+                const delta = noteIndex === 0 ? PPQ : 0;
+                events.push(...this.writeVariableLength(delta), 0x80, noteNumber, 0x40);
+            });
+        });
+
+        // End of track
+        events.push(...this.writeVariableLength(PPQ), 0xFF, 0x2F, 0x00);
+
+        const trackData = new Uint8Array(events);
+        const header = new Uint8Array([
+            ...this.stringToBytes('MThd'),
+            0x00, 0x00, 0x00, 0x06,
+            0x00, 0x01,
+            0x00, 0x01,
+            0x01, 0xE0 // 480 PPQ
+        ]);
+
+        const trackHeader = new Uint8Array([
+            ...this.stringToBytes('MTrk'),
+            ...this.numberToBytes(trackData.length, 4)
+        ]);
+
+        return new Blob([header, trackHeader, trackData], { type: 'audio/midi' });
+    }
+
+    /**
+     * Build a MusicXML document string for the sequence.
+     */
+    createMusicXML(sequence, tempo = 120, timeSignature = '4/4') {
+        const sanitizedSequence = this.sanitizeSequence(sequence);
+        if (!sanitizedSequence.length) {
+            throw new Error('Séquence vide');
+        }
+
+        const [beats = 4, beatType = 4] = timeSignature.split('/').map(Number);
+        const divisions = 1;
+        const tempoDirection = `
+            <direction>
+                <direction-type>
+                    <metronome>
+                        <beat-unit>quarter</beat-unit>
+                        <per-minute>${tempo}</per-minute>
+                    </metronome>
+                </direction-type>
+                <sound tempo="${tempo}"/>
+            </direction>
+        `;
+
+        const measures = sanitizedSequence.map((chord, index) => {
+            const chordRoot = this.getRootFromName(chord.name);
+            const pitch = this.getPitchFromNote(chord.notes[0] || chordRoot.step);
+            const harmony = `
+                <harmony>
+                    <root>
+                        <root-step>${chordRoot.step}</root-step>
+                        ${chordRoot.alter !== 0 ? `<root-alter>${chordRoot.alter}</root-alter>` : ''}
+                    </root>
+                    <kind>${this.getMusicXMLKind(chord)}</kind>
+                </harmony>
+            `;
+
+            const attributes = index === 0 ? `
+                <attributes>
+                    <divisions>${divisions}</divisions>
+                    <key>
+                        <fifths>${this.keyToFifths(chordRoot.step)}</fifths>
+                    </key>
+                    <time>
+                        <beats>${beats}</beats>
+                        <beat-type>${beatType}</beat-type>
+                    </time>
+                    <clef>
+                        <sign>G</sign>
+                        <line>2</line>
+                    </clef>
+                </attributes>
+            ` : '';
+
+            const note = `
+                <note>
+                    <pitch>
+                        <step>${pitch.step}</step>
+                        ${pitch.alter !== 0 ? `<alter>${pitch.alter}</alter>` : ''}
+                        <octave>${pitch.octave}</octave>
+                    </pitch>
+                    <duration>${divisions}</duration>
+                    <type>quarter</type>
+                </note>
+            `;
+
+            return `
+                <measure number="${index + 1}">
+                    ${index === 0 ? tempoDirection : ''}
+                    ${attributes}
+                    ${harmony}
+                    ${note}
+                </measure>
+            `;
+        }).join('\n');
+
+        return `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>SayChord</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    ${measures}
+  </part>
+</score-partwise>`;
+    }
+
+    /**
+     * Build an ABC notation string for the sequence.
+     */
+    createABC(sequence, tempo = 120, timeSignature = '4/4') {
+        const sanitizedSequence = this.sanitizeSequence(sequence);
+        if (!sanitizedSequence.length) {
+            throw new Error('Séquence vide');
+        }
+
+        const root = this.getRootFromName(sanitizedSequence[0].name);
+        const chordsLine = sanitizedSequence
+            .map(chord => `"${this.formatABCChord(chord.name)}" z`)
+            .join(' | ');
+
+        return [
+            'X:1',
+            'T:SayChord Sequence',
+            `M:${timeSignature}`,
+            'L:1/4',
+            `Q:1/4=${tempo}`,
+            `K:${root.step}`,
+            chordsLine + ' |'
+        ].join('\n');
+    }
+
+    /**
+     * Download helpers
+     */
+    downloadBlob(blob, filename) {
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = filename;
+        document.body.appendChild(anchor);
+        anchor.click();
+        anchor.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }
+
+    downloadText(content, filename, mimeType) {
+        const blob = new Blob([content], { type: mimeType });
+        this.downloadBlob(blob, filename);
+    }
+
+    downloadMIDI(sequence, tempo) {
+        const blob = this.createMIDI(sequence, tempo);
+        this.downloadBlob(blob, this.generateFilename('mid'));
+        return blob;
+    }
+
+    downloadMusicXML(sequence, tempo, timeSignature) {
+        const xml = this.createMusicXML(sequence, tempo, timeSignature);
+        this.downloadText(xml, this.generateFilename('musicxml'), 'application/vnd.recordare.musicxml+xml');
+        return xml;
+    }
+
+    downloadABC(sequence, tempo, timeSignature) {
+        const abc = this.createABC(sequence, tempo, timeSignature);
+        this.downloadText(abc, this.generateFilename('abc'), 'text/vnd.abc');
+        return abc;
+    }
+
+    /** Utility helpers **/
+    noteNameToMidi(noteName) {
+        if (!noteName) return null;
+        const match = noteName.trim().match(/^([A-Ga-g])([#b]?)(\d+)?$/);
+        if (!match) {
+            return null;
+        }
+
+        const step = match[1].toUpperCase();
+        const accidental = match[2] || '';
+        const octave = match[3] !== undefined ? parseInt(match[3], 10) : 4;
+        const baseOffset = this.noteOffsets[step];
+        const semitone = accidental === '#'
+            ? 1
+            : accidental.toLowerCase() === 'b'
+                ? -1
+                : 0;
+        return 12 * (octave + 1) + baseOffset + semitone;
+    }
+
+    getPitchFromNote(noteName) {
+        const match = noteName && noteName.match(/^([A-Ga-g])([#b]?)(\d+)?$/);
+        const step = match ? match[1].toUpperCase() : 'C';
+        const accidental = match ? match[2] || '' : '';
+        const octave = match && match[3] ? parseInt(match[3], 10) : 4;
+        const alter = accidental === '#'
+            ? 1
+            : accidental.toLowerCase() === 'b'
+                ? -1
+                : 0;
+        return { step, alter, octave };
+    }
+
+    getRootFromName(name = 'C') {
+        const match = name.trim().match(/^([A-Ga-g])([#b]?)/);
+        const step = match ? match[1].toUpperCase() : 'C';
+        const accidental = match && match[2] ? match[2] : '';
+        const alter = accidental === '#'
+            ? 1
+            : accidental.toLowerCase() === 'b'
+                ? -1
+                : 0;
+        return { step, alter };
+    }
+
+    getMusicXMLKind(chord) {
+        const category = (chord.category || '').toLowerCase();
+        if (category.includes('mineur')) return 'minor';
+        if (category.includes('dominant')) return 'dominant';
+        if (category.includes('demi')) return 'half-diminished';
+        if (category.includes('dim')) return 'diminished';
+        if (category.includes('aug')) return 'augmented';
+        return 'major';
+    }
+
+    keyToFifths(step) {
+        const mapping = { C: 0, G: 1, D: 2, A: 3, E: 4, B: 5, F: -1 };
+        return mapping[step] ?? 0;
+    }
+
+    formatABCChord(name) {
+        return (name || '').replace(/"/g, "'");
+    }
+
+    stringToBytes(str) {
+        return Array.from(str).map(char => char.charCodeAt(0));
+    }
+
+    numberToBytes(value, byteCount) {
+        const bytes = new Array(byteCount).fill(0);
+        for (let i = byteCount - 1; i >= 0; i -= 1) {
+            bytes[i] = value & 0xFF;
+            value >>= 8;
+        }
+        return bytes;
+    }
+
+    writeVariableLength(value) {
+        let buffer = value & 0x7F;
+        const bytes = [];
+        while ((value >>= 7)) {
+            buffer <<= 8;
+            buffer |= ((value & 0x7F) | 0x80);
+        }
+        while (true) {
+            bytes.push(buffer & 0xFF);
+            if (buffer & 0x80) {
+                buffer >>= 8;
+            } else {
+                break;
+            }
+        }
+        return bytes;
+    }
+
+    generateFilename(extension) {
+        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        return `saychord-sequence-${timestamp}.${extension}`;
+    }
+}
+
+export default SequenceExporter;

--- a/js/sequence-manager.js
+++ b/js/sequence-manager.js
@@ -3,6 +3,8 @@
  * Version adaptée pour GitHub Pages avec gestion des erreurs et compatibilité navigateur
  */
 
+import SequenceExporter from './sequence-exporter.js';
+
 class SequenceManager {
     constructor(synthesizer) {
         this.synthesizer = synthesizer;
@@ -22,6 +24,12 @@ class SequenceManager {
         this.loopButton = null;
         this.tempoSlider = null;
         this.tempoValue = null;
+        this.exportWavButton = null;
+        this.exportPdfButton = null;
+        this.exportMidiButton = null;
+        this.exportMusicXmlButton = null;
+        this.exportAbcButton = null;
+        this.exporter = new SequenceExporter();
         
         // Initialiser les éléments DOM après le chargement de la page
         document.addEventListener('DOMContentLoaded', () => {
@@ -38,6 +46,11 @@ class SequenceManager {
             this.loopButton = document.getElementById('loop-button');
             this.tempoSlider = document.getElementById('tempo-slider');
             this.tempoValue = document.getElementById('tempo-value');
+            this.exportWavButton = document.getElementById('export-wav');
+            this.exportPdfButton = document.getElementById('export-pdf');
+            this.exportMidiButton = document.getElementById('export-midi');
+            this.exportMusicXmlButton = document.getElementById('export-musicxml');
+            this.exportAbcButton = document.getElementById('export-abc');
             
             // Initialiser les écouteurs d'événements
             if (this.playButton) {
@@ -56,6 +69,26 @@ class SequenceManager {
                 this.tempoSlider.addEventListener('input', (e) => {
                     this.setTempo(parseInt(e.target.value));
                 });
+            }
+
+            if (this.exportWavButton) {
+                this.exportWavButton.addEventListener('click', () => this.exportToWAV());
+            }
+
+            if (this.exportPdfButton) {
+                this.exportPdfButton.addEventListener('click', () => this.exportToPDF());
+            }
+
+            if (this.exportMidiButton) {
+                this.exportMidiButton.addEventListener('click', () => this.exportToMIDI());
+            }
+
+            if (this.exportMusicXmlButton) {
+                this.exportMusicXmlButton.addEventListener('click', () => this.exportToMusicXML());
+            }
+
+            if (this.exportAbcButton) {
+                this.exportAbcButton.addEventListener('click', () => this.exportToABC());
             }
             
             console.log('Éléments DOM du gestionnaire de séquences initialisés');
@@ -392,16 +425,11 @@ class SequenceManager {
     // Exporter la séquence au format WAV
     exportToWAV() {
         try {
-            // Vérifier que la séquence n'est pas vide
-            if (this.sequence.length === 0) {
-                console.warn('La séquence est vide, impossible d\'exporter');
-                alert('La séquence est vide. Veuillez ajouter des accords avant d\'exporter.');
+            if (!this.ensureSequenceReady('WAV')) {
                 return false;
             }
-            
-            // Simuler l'export pour la démo GitHub Pages
-            alert('Fonctionnalité d\'export WAV simulée pour la démo GitHub Pages.\n\nDans la version complète, cette fonction permettrait d\'exporter la séquence d\'accords au format audio WAV.');
-            
+
+            alert('Export WAV complet disponible dans la version native. Utilisez les exports MIDI, MusicXML ou ABC pour récupérer la séquence immédiatement.');
             console.log('Export WAV simulé pour la démo GitHub Pages');
             return true;
         } catch (error) {
@@ -410,25 +438,93 @@ class SequenceManager {
         }
     }
 
-    // Exporter la séquence au format PDF
     exportToPDF() {
         try {
-            // Vérifier que la séquence n'est pas vide
-            if (this.sequence.length === 0) {
-                console.warn('La séquence est vide, impossible d\'exporter');
-                alert('La séquence est vide. Veuillez ajouter des accords avant d\'exporter.');
+            if (!this.ensureSequenceReady('PDF')) {
                 return false;
             }
-            
-            // Simuler l'export pour la démo GitHub Pages
-            alert('Fonctionnalité d\'export PDF simulée pour la démo GitHub Pages.\n\nDans la version complète, cette fonction permettrait d\'exporter la notation des accords au format PDF.');
-            
+
+            alert('Export PDF complet disponible dans la version native. Utilisez MusicXML pour obtenir une partition exploitable.');
             console.log('Export PDF simulé pour la démo GitHub Pages');
             return true;
         } catch (error) {
             console.error('Erreur lors de l\'export PDF :', error);
             return false;
         }
+    }
+
+    exportToMIDI() {
+        try {
+            if (!this.ensureSequenceReady('MIDI')) {
+                return false;
+            }
+
+            const midiBlob = this.exporter.downloadMIDI(this.prepareSequenceForExport(), this.tempo);
+            console.log('Export MIDI réussi', midiBlob);
+            return midiBlob;
+        } catch (error) {
+            console.error('Erreur lors de l\'export MIDI :', error);
+            alert('Impossible de créer le fichier MIDI. Consultez la console pour plus de détails.');
+            return false;
+        }
+    }
+
+    exportToMusicXML() {
+        try {
+            if (!this.ensureSequenceReady('MusicXML')) {
+                return false;
+            }
+
+            const xmlContent = this.exporter.downloadMusicXML(this.prepareSequenceForExport(), this.tempo, this.timeSignature);
+            console.log('Export MusicXML réussi');
+            return xmlContent;
+        } catch (error) {
+            console.error('Erreur lors de l\'export MusicXML :', error);
+            alert('Impossible de créer le fichier MusicXML. Consultez la console pour plus de détails.');
+            return false;
+        }
+    }
+
+    exportToABC() {
+        try {
+            if (!this.ensureSequenceReady('ABC')) {
+                return false;
+            }
+
+            const abcContent = this.exporter.downloadABC(this.prepareSequenceForExport(), this.tempo, this.timeSignature);
+            console.log('Export ABC réussi');
+            return abcContent;
+        } catch (error) {
+            console.error('Erreur lors de l\'export ABC :', error);
+            alert('Impossible de créer le fichier ABC. Consultez la console pour plus de détails.');
+            return false;
+        }
+    }
+
+    exportWAV() {
+        return this.exportToWAV();
+    }
+
+    exportPDF() {
+        return this.exportToPDF();
+    }
+
+    prepareSequenceForExport() {
+        return this.sequence.map((chord, index) => ({
+            nom: chord.nom || chord.name || `Accord ${index + 1}`,
+            name: chord.nom || chord.name || `Accord ${index + 1}`,
+            notes: Array.isArray(chord.notes) ? chord.notes : [],
+            categorie: chord.categorie || chord.category || 'majeur'
+        }));
+    }
+
+    ensureSequenceReady(label) {
+        if (this.sequence.length === 0) {
+            console.warn(`La séquence est vide, impossible d'exporter (${label})`);
+            alert('La séquence est vide. Veuillez ajouter des accords avant d\'exporter.');
+            return false;
+        }
+        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
- add a SequenceExporter module that turns dictated chord sequences into downloadable MIDI, MusicXML and ABC files and wire it into the sequence manager
- surface the new export controls in the UI/CSS, keep WAV/PDF notices for the demo build, and document the additions
- include a GPTs builder configuration file so AiXelMusicOrchestrator can ingest SayChord knowledge and trigger the export helpers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd8d408408322a978533dafc660b9)