### PR TITLE
Fix audio enhancer integration, add presets & JSON export, and correct sequence handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
                 <div class="export-options">
                     <button id="export-wav" class="btn">Exporter en WAV</button>
                     <button id="export-pdf" class="btn btn-secondary">Exporter en PDF</button>
+                    <button id="export-json" class="btn btn-secondary">Exporter en JSON</button>
                 </div>
             </div>
         </div>

--- a/js/audio-enhancer.js
+++ b/js/audio-enhancer.js
@@ -7,11 +7,13 @@ class AudioEnhancer {
     constructor(synthesizer) {
         this.synthesizer = synthesizer;
         this.initialized = false;
+        this.pendingPreset = null;
+        this.activePreset = null;
         this.initialize();
     }
     
     initialize() {
-        if (!this.synthesizer || !this.synthesizer.audioContext) {
+        if (!this.synthesizer) {
             console.warn('Impossible d\'initialiser l\'améliorateur audio : synthétiseur non disponible');
             return;
         }
@@ -20,13 +22,20 @@ class AudioEnhancer {
             // Initialiser l'améliorateur audio
             console.log('Améliorateur audio initialisé');
             this.initialized = true;
-            
+
             // Ajouter des messages d'aide spécifiques pour GitHub Pages
             if (window.location.hostname.includes('github.io')) {
                 document.addEventListener('DOMContentLoaded', () => {
                     this.addHelpMessages();
                 });
             }
+
+            document.addEventListener('synthesizer:initialized', () => {
+                if (this.pendingPreset) {
+                    this.applyPreset(this.pendingPreset);
+                    this.pendingPreset = null;
+                }
+            });
         } catch (error) {
             console.error('Erreur lors de l\'initialisation de l\'améliorateur audio :', error);
         }
@@ -46,6 +55,64 @@ class AudioEnhancer {
             
             controlPanel.appendChild(helpMessage);
         }
+    }
+
+    applyPreset(presetName) {
+        const presetMap = {
+            warm: { volume: 0.7, reverb: 0.25 },
+            bright: { volume: 0.8, reverb: 0.15 },
+            dry: { volume: 0.75, reverb: 0.05 }
+        };
+
+        const preset = presetMap[presetName];
+        if (!preset) {
+            console.warn('Preset audio inconnu :', presetName);
+            return false;
+        }
+
+        if (!this.synthesizer || !this.synthesizer.initialized) {
+            this.pendingPreset = presetName;
+            return false;
+        }
+
+        if (this.synthesizer.masterGain) {
+            this.synthesizer.masterGain.gain.value = preset.volume;
+        }
+
+        if (this.synthesizer.reverbGain) {
+            this.synthesizer.reverbGain.gain.value = preset.reverb;
+        }
+
+        this.activePreset = presetName;
+        return true;
+    }
+
+    optimizeForVoiceRecognition() {
+        if (!this.synthesizer || !this.synthesizer.initialized) {
+            return null;
+        }
+
+        const previousSettings = {
+            volume: this.synthesizer.masterGain?.gain.value ?? 0.7,
+            reverb: this.synthesizer.reverbGain?.gain.value ?? 0.2
+        };
+
+        if (this.synthesizer.masterGain) {
+            this.synthesizer.masterGain.gain.value = Math.min(previousSettings.volume, 0.4);
+        }
+
+        if (this.synthesizer.reverbGain) {
+            this.synthesizer.reverbGain.gain.value = 0.05;
+        }
+
+        return () => {
+            if (this.synthesizer.masterGain) {
+                this.synthesizer.masterGain.gain.value = previousSettings.volume;
+            }
+            if (this.synthesizer.reverbGain) {
+                this.synthesizer.reverbGain.gain.value = previousSettings.reverb;
+            }
+        };
     }
 }
 

--- a/js/chord-dictionary.js
+++ b/js/chord-dictionary.js
@@ -14,7 +14,7 @@ class ChordDictionary {
      */
     async loadDictionary() {
         try {
-            const response = await fetch('/chord-dictionary.json');
+            const response = await fetch(new URL('../chord-dictionary.json', import.meta.url));
             if (!response.ok) {
                 throw new Error(`Erreur HTTP: ${response.status}`);
             }

--- a/js/sequence-manager.js
+++ b/js/sequence-manager.js
@@ -170,7 +170,7 @@ class SequenceManager {
             
             // Arrêter le son
             if (this.synthesizer) {
-                this.synthesizer.stopAllOscillators();
+                this.synthesizer.stopAllNotes();
             }
             
             // Mettre à jour l'interface
@@ -427,6 +427,70 @@ class SequenceManager {
             return true;
         } catch (error) {
             console.error('Erreur lors de l\'export PDF :', error);
+            return false;
+        }
+    }
+
+    buildSequenceExport() {
+        const measures = this.splitSequenceIntoMeasures();
+
+        return {
+            tempo: this.tempo,
+            timeSignature: this.timeSignature,
+            loopLength: this.loopLength,
+            totalChords: this.sequence.length,
+            measures
+        };
+    }
+
+    splitSequenceIntoMeasures() {
+        if (this.sequence.length === 0) {
+            return [];
+        }
+
+        const measures = [];
+        let measureIndex = 1;
+
+        for (let i = 0; i < this.sequence.length; i += this.loopLength) {
+            const slice = this.sequence.slice(i, i + this.loopLength);
+            measures.push({
+                measure: measureIndex,
+                chords: slice.map((chord, index) => ({
+                    position: i + index + 1,
+                    name: chord.nom,
+                    notes: chord.notes || []
+                }))
+            });
+            measureIndex += 1;
+        }
+
+        return measures;
+    }
+
+    exportToJSON() {
+        try {
+            if (this.sequence.length === 0) {
+                console.warn('La séquence est vide, impossible d\'exporter');
+                alert('La séquence est vide. Veuillez ajouter des accords avant d\'exporter.');
+                return false;
+            }
+
+            const data = this.buildSequenceExport();
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = 'saychord-sequence.json';
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+
+            console.log('Export JSON terminé');
+            return true;
+        } catch (error) {
+            console.error('Erreur lors de l\'export JSON :', error);
             return false;
         }
     }

--- a/js/synthesizer.js
+++ b/js/synthesizer.js
@@ -9,6 +9,7 @@ class Synthesizer {
         this.initPromise = null;
         this.fmSynths = {};
         this.reverb = null;
+        this.reverbGain = null;
         this.isPlaying = false;
     }
 
@@ -39,6 +40,7 @@ class Synthesizer {
                 // Marquer comme initialisé
                 this.initialized = true;
                 console.log("Synthétiseur initialisé avec succès");
+                document.dispatchEvent(new CustomEvent('synthesizer:initialized'));
                 resolve();
             } catch (error) {
                 console.error("Erreur lors de l'initialisation du synthétiseur:", error);
@@ -70,6 +72,7 @@ class Synthesizer {
         // Créer un nœud de gain pour contrôler le niveau de réverbération
         const reverbGain = this.audioContext.createGain();
         reverbGain.gain.value = 0.2;
+        this.reverbGain = reverbGain;
         
         // Connecter le convolver au gain de réverbération
         convolver.connect(reverbGain);

--- a/js/ui-controller.js
+++ b/js/ui-controller.js
@@ -6,24 +6,25 @@ import VoiceRecognition from './voice-recognition.js';
 import SequenceManager from './sequence-manager.js';
 
 class UIController {
-    constructor() {
+    constructor(chordDictionary, voiceRecognition, synthesizer, sequenceManager) {
         // Initialiser les modules principaux
-        this.chordDictionary = new ChordDictionary();
-        this.synthesizer = new Synthesizer();
-        this.voiceRecognition = new VoiceRecognition(this.chordDictionary);
-        this.sequenceManager = new SequenceManager(this.synthesizer);
+        this.chordDictionary = chordDictionary || new ChordDictionary();
+        this.synthesizer = synthesizer || new Synthesizer();
+        this.voiceRecognition = voiceRecognition || new VoiceRecognition(this.chordDictionary);
+        this.sequenceManager = sequenceManager || new SequenceManager(this.synthesizer);
         
         // Éléments DOM
         this.micButton = document.getElementById('mic-button');
-        this.recognizedText = document.getElementById('recognized-text');
-        this.chordDisplay = document.getElementById('chord-display');
-        this.sequenceContainer = document.getElementById('sequence-container');
-        this.tempoInput = document.getElementById('tempo-input');
+        this.chordName = document.getElementById('chord-name');
+        this.chordNotes = document.getElementById('chord-notes');
+        this.sequenceList = document.getElementById('sequence-list');
+        this.tempoSlider = document.getElementById('tempo-slider');
         this.playButton = document.getElementById('play-button');
         this.stopButton = document.getElementById('stop-button');
-        this.clearButton = document.getElementById('clear-button');
+        this.loopButton = document.getElementById('loop-button');
         this.exportWavButton = document.getElementById('export-wav');
         this.exportPdfButton = document.getElementById('export-pdf');
+        this.exportJsonButton = document.getElementById('export-json');
         
         // État de l'interface
         this.isListening = false;
@@ -34,7 +35,9 @@ class UIController {
 
     async initializeUI() {
         // Charger le dictionnaire d'accords
-        await this.chordDictionary.loadDictionary('./chord-dictionary.json');
+        if (!this.chordDictionary.isLoaded) {
+            await this.chordDictionary.loadDictionary();
+        }
         
         // Configurer les gestionnaires d'événements
         this.setupEventListeners();
@@ -57,24 +60,21 @@ class UIController {
         
         // Contrôles de séquence
         if (this.playButton) {
-            this.playButton.addEventListener('click', () => this.sequenceManager.play());
+            this.playButton.addEventListener('click', () => this.sequenceManager.playSequence());
         }
         
         if (this.stopButton) {
-            this.stopButton.addEventListener('click', () => this.sequenceManager.stop());
+            this.stopButton.addEventListener('click', () => this.sequenceManager.stopSequence());
         }
-        
-        if (this.clearButton) {
-            this.clearButton.addEventListener('click', () => {
-                this.sequenceManager.clearSequence();
-                this.updateSequenceDisplay();
-            });
+
+        if (this.loopButton) {
+            this.loopButton.addEventListener('click', () => this.sequenceManager.toggleLoop());
         }
         
         // Contrôle du tempo
-        if (this.tempoInput) {
-            this.tempoInput.addEventListener('change', () => {
-                const tempo = parseInt(this.tempoInput.value);
+        if (this.tempoSlider) {
+            this.tempoSlider.addEventListener('input', () => {
+                const tempo = parseInt(this.tempoSlider.value);
                 this.sequenceManager.setTempo(tempo);
                 this.updateTempoDisplay();
             });
@@ -87,6 +87,10 @@ class UIController {
         
         if (this.exportPdfButton) {
             this.exportPdfButton.addEventListener('click', () => this.sequenceManager.exportToPDF());
+        }
+
+        if (this.exportJsonButton) {
+            this.exportJsonButton.addEventListener('click', () => this.sequenceManager.exportToJSON());
         }
         
         // Écouter l'événement de lecture d'accord
@@ -107,8 +111,8 @@ class UIController {
                 this.micButton.innerHTML = '<i class="fas fa-microphone"></i>';
             }
             
-            if (this.recognizedText) {
-                this.recognizedText.textContent = "Dictez un accord pour commencer";
+            if (this.chordNotes) {
+                this.chordNotes.textContent = "Dictez un accord pour commencer";
             }
         } else {
             // Démarrer la reconnaissance
@@ -125,35 +129,43 @@ class UIController {
                 this.micButton.innerHTML = '<i class="fas fa-stop"></i>';
             }
             
-            if (this.recognizedText) {
-                this.recognizedText.textContent = "Écoute...";
+            if (this.chordNotes) {
+                this.chordNotes.textContent = "Écoute...";
             }
         }
     }
 
     handleRecognitionResult(chord, text) {
-        // Mettre à jour l'affichage du texte reconnu
-        if (this.recognizedText) {
-            this.recognizedText.textContent = text;
-        }
-        
         // Si un accord a été reconnu
         if (chord) {
             // Afficher l'accord
-            if (this.chordDisplay) {
-                this.chordDisplay.textContent = chord.nom;
+            if (this.chordName) {
+                this.chordName.textContent = chord.nom;
             }
             
+            if (this.chordNotes) {
+                const notes = chord.notes?.length ? chord.notes.join(' • ') : 'Notes indisponibles';
+                const normalizedText = text?.trim();
+                const noteSuffix = normalizedText && normalizedText.toLowerCase() !== chord.nom.toLowerCase()
+                    ? ` (Reconnu : ${normalizedText})`
+                    : '';
+                this.chordNotes.textContent = `Notes : ${notes}${noteSuffix}`;
+            }
+
             // Jouer l'accord
             this.synthesizer.playChord(chord);
             
             // Ajouter l'accord à la séquence
             this.sequenceManager.addChord(chord);
-            this.updateSequenceDisplay();
         } else {
             // Aucun accord reconnu
-            if (this.chordDisplay) {
-                this.chordDisplay.textContent = "Accord non reconnu";
+            if (this.chordName) {
+                this.chordName.textContent = "Accord non reconnu";
+            }
+            if (this.chordNotes) {
+                this.chordNotes.textContent = text
+                    ? `Texte reconnu : ${text}`
+                    : "Aucun accord reconnu";
             }
         }
         
@@ -167,8 +179,8 @@ class UIController {
 
     handleRecognitionError(error) {
         // Afficher l'erreur
-        if (this.recognizedText) {
-            this.recognizedText.textContent = error;
+        if (this.chordNotes) {
+            this.chordNotes.textContent = error;
         }
         
         // Réinitialiser l'état d'écoute
@@ -180,34 +192,9 @@ class UIController {
     }
 
     updateSequenceDisplay() {
-        if (!this.sequenceContainer) return;
-        
-        // Vider le conteneur
-        this.sequenceContainer.innerHTML = '';
-        
-        // Si la séquence est vide
-        if (this.sequenceManager.sequence.length === 0) {
-            const emptyMessage = document.createElement('p');
-            emptyMessage.textContent = "La séquence est vide. Dictez des accords pour les ajouter.";
-            this.sequenceContainer.appendChild(emptyMessage);
-            return;
+        if (this.sequenceManager?.updateSequenceDisplay) {
+            this.sequenceManager.updateSequenceDisplay();
         }
-        
-        // Créer un élément pour chaque accord
-        this.sequenceManager.sequence.forEach((chord, index) => {
-            const chordElement = document.createElement('div');
-            chordElement.className = 'sequence-chord';
-            chordElement.textContent = chord.nom;
-            chordElement.dataset.index = index;
-            
-            // Ajouter un gestionnaire de clic pour supprimer l'accord
-            chordElement.addEventListener('click', () => {
-                this.sequenceManager.removeChord(index);
-                this.updateSequenceDisplay();
-            });
-            
-            this.sequenceContainer.appendChild(chordElement);
-        });
     }
 
     highlightPlayingChord(index) {
@@ -223,11 +210,11 @@ class UIController {
     }
 
     updateTempoDisplay() {
-        if (this.tempoInput) {
-            this.tempoInput.value = this.sequenceManager.tempo;
+        if (this.tempoSlider) {
+            this.tempoSlider.value = this.sequenceManager.tempo;
         }
         
-        const tempoDisplay = document.getElementById('tempo-display');
+        const tempoDisplay = document.getElementById('tempo-value');
         if (tempoDisplay) {
             tempoDisplay.textContent = `${this.sequenceManager.tempo} BPM`;
         }
@@ -244,9 +231,9 @@ class UIController {
             `;
             
             // Insérer avant le conteneur de l'application
-            const appContainer = document.getElementById('app-container');
-            if (appContainer) {
-                appContainer.parentNode.insertBefore(permissionRequest, appContainer);
+            const appSection = document.getElementById('app');
+            if (appSection) {
+                appSection.querySelector('.container')?.prepend(permissionRequest);
             } else {
                 document.body.insertBefore(permissionRequest, document.body.firstChild);
             }

--- a/js/voice-recognition.js
+++ b/js/voice-recognition.js
@@ -9,6 +9,8 @@ class VoiceRecognition {
         this.isListening = false;
         this.onResultCallback = null;
         this.onErrorCallback = null;
+        this.onStartCallback = null;
+        this.onEndCallback = null;
         this.adapter = new VoiceRecognitionAdapter(); // Utilise l'adaptateur pour améliorer la reconnaissance
         this.setupRecognition();
     }
@@ -57,6 +59,9 @@ class VoiceRecognition {
             this.recognition.start();
             this.isListening = true;
             console.log("Reconnaissance vocale démarrée");
+            if (this.onStartCallback) {
+                this.onStartCallback();
+            }
             
             // Afficher une demande d'autorisation si nécessaire
             this.showPermissionRequest();
@@ -125,6 +130,17 @@ class VoiceRecognition {
     handleEnd() {
         this.isListening = false;
         console.log("Session de reconnaissance vocale terminée");
+        if (this.onEndCallback) {
+            this.onEndCallback();
+        }
+    }
+
+    onStart(callback) {
+        this.onStartCallback = callback;
+    }
+
+    onEnd(callback) {
+        this.onEndCallback = callback;
     }
 
     showPermissionRequest() {
@@ -135,7 +151,8 @@ class VoiceRecognition {
             
             // Ajouter un gestionnaire d'événements au bouton d'autorisation
             const permissionButton = permissionRequest.querySelector('button');
-            if (permissionButton) {
+            if (permissionButton && !permissionButton.dataset.listenerAdded) {
+                permissionButton.dataset.listenerAdded = 'true';
                 permissionButton.addEventListener('click', () => {
                     // Demander l'autorisation d'utiliser le microphone
                     navigator.mediaDevices.getUserMedia({ audio: true })
@@ -167,7 +184,7 @@ class VoiceRecognition {
         }
         
         // Afficher un message d'erreur dans l'interface
-        const appContainer = document.querySelector('#app-container');
+        const appContainer = document.querySelector('#app');
         if (appContainer) {
             const errorElement = document.createElement('div');
             errorElement.className = 'error-message';


### PR DESCRIPTION
### Motivation
- Fix audio initialization and control so presets and reverb can be applied reliably after synth init.
- Resolve sequence/track splitting issues so sequences can be exported and split into measures for downstream tools.
- Align UI bindings with shared modules and ensure playback/loop controls call the correct `SequenceManager` APIs.
- Improve voice recognition UX by adding start/end hooks and preventing duplicate permission button listeners.

### Description
- Added `reverbGain` and dispatched a `synthesizer:initialized` event from `Synthesizer.initialize()` so enhancers can apply pending presets when ready, and wired `reverbGain` control into the audio graph.
- Implemented `AudioEnhancer.applyPreset()` and `optimizeForVoiceRecognition()` to set `masterGain` and `reverbGain`, with deferred application when the synth isn't initialized.
- Fixed `ChordDictionary.loadDictionary()` to use `new URL(..., import.meta.url)` for module-relative fetches so the JSON loads in module contexts.
- Updated `UIController` to accept injected modules, corrected DOM element IDs, wired correct `SequenceManager` methods (`playSequence`, `stopSequence`, `toggleLoop`), and added an `Export JSON` button.
- Fixed sequence stop behavior to call `synthesizer.stopAllNotes()` and added `splitSequenceIntoMeasures()`, `buildSequenceExport()` and `exportToJSON()` to `SequenceManager` for structured exports.
- Added safety in `VoiceRecognition` to expose `onStart`/`onEnd` callbacks and avoid adding duplicate listeners to permission buttons, and improved where browser-support errors are shown.

### Testing
- Started a local static server with `python -m http.server 8000` and verified the app loaded in a headless browser via a Playwright script that took a screenshot (succeeded).
- Performed a repository commit of the changes (local commit succeeded).
- No unit tests were added or executed; changes were validated via the smoke test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951a2fc5d088322b1021275038888e2)